### PR TITLE
Make spree_tax_cloud play nice with other tax rates.

### DIFF
--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -1,13 +1,25 @@
 Spree::Order.class_eval do
 
-  self.state_machine.after_transition to: :complete, do: :capture_tax_cloud  
+  self.state_machine.after_transition to: :complete, do: :capture_tax_cloud
 
   def capture_tax_cloud
+    if is_taxed_using_tax_cloud? == false
+      return
+    end
+
     transaction = Spree::TaxCloud.transaction_from_order(self)
-    response =  transaction.authorized_with_capture 
+    response =  transaction.authorized_with_capture
     if response != "OK"
       Rails.logger.error "ERROR: TaxCloud returned an order capture response of #{response}."
     end
   end
-  
+
+  def is_taxed_using_tax_cloud?
+    # TaxRate.match is used here to check if the order is taxable by Tax Cloud.
+    # It's not possible check against the order's tax adjustments because
+    # an adjustment is not created for 0% rates. However, US orders must be
+    # submitted to Tax Cloud even when the rate is 0%.
+    is_tax_cloud = Spree::TaxRate.match(tax_zone).any? { |rate| rate.calculator_type == "Spree::Calculator::TaxCloudCalculator" }
+    return is_tax_cloud
+  end
 end

--- a/app/models/spree/tax_cloud.rb
+++ b/app/models/spree/tax_cloud.rb
@@ -63,6 +63,6 @@ module Spree
         raise 'TaxCloud::CartItem cannot be made from this item.'
       end
     end
-    
+
   end
 end


### PR DESCRIPTION
This stops spree_tax_cloud committing tax cloud transactions for orders that do not use the tax cloud calculator. Stores that ship into and outside the US are likely to have multiple tax rates, with only the US tax rate being applicable for orders into the US.

This may not be the cleanest solution but it does fix the problem I'm having using spree_tax_cloud in a store that has multiple tax rates.

To get the test passing I had to add the states to the US zone. I think spree was defaulting to the US zone previously. With multiple zones it needs to be given a little more information to pick the right zone.

Unfortunately I haven't been able to verify the other tests. I can't get to taxcloud on the network I'm on at the moment :confounded:. I'd appreciate it if someone were able to verify the tests are still ok. 
