### PR TITLE
Upgrade to spree's master branch version - 2.4.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'spree', git: 'https://github.com/spree/spree.git', branch: 'master'
+
 gemspec

--- a/spree_tax_cloud.gemspec
+++ b/spree_tax_cloud.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_api'
   s.add_dependency 'spree_backend'
-  s.add_dependency 'spree_core', '~> 2.3.1'
+  s.add_dependency 'spree_core', '~> 2.4.0.beta'
   s.add_dependency 'spree_frontend'
 
   s.add_runtime_dependency 'savon', '~> 2.5.1'


### PR DESCRIPTION
I'm developing a store against edge Spree and this change is required for bundler to not complain about the version differences.
