### PR TITLE
Make admin templates work with 3-0-stable.

### DIFF
--- a/app/controllers/spree/admin/tax_cloud_settings_controller.rb
+++ b/app/controllers/spree/admin/tax_cloud_settings_controller.rb
@@ -10,6 +10,9 @@ module Spree
         params.each do |name, value|
           Spree::Config[name] = value if Spree::Config.has_preference? name
         end
+
+        Spree::TaxCloud.update_config
+
         flash[:success] = Spree.t(:successfully_updated, resource: Spree.t(:tax_cloud_settings))
         redirect_to edit_admin_tax_cloud_settings_path
       end

--- a/app/models/spree/app_configuration_decorator.rb
+++ b/app/models/spree/app_configuration_decorator.rb
@@ -4,12 +4,8 @@ Spree::AppConfiguration.class_eval do
   preference :taxcloud_default_product_tic, :string, default: '00000'
   preference :taxcloud_shipping_tic, :string, default: '11010'
   preference :taxcloud_usps_user_id, :string
-  
-  TaxCloud.configure do |config|
-    config.api_login_id = Spree::Config.taxcloud_api_login_id
-    config.api_key = Spree::Config.taxcloud_api_key
-    config.usps_username = Spree::Config.taxcloud_usps_user_id
-  end
-  
+
+  Spree::TaxCloud.update_config
+
   Rails.application.config.spree.calculators.tax_rates << Spree::Calculator::TaxCloudCalculator
 end

--- a/app/models/spree/tax_cloud.rb
+++ b/app/models/spree/tax_cloud.rb
@@ -1,5 +1,14 @@
 module Spree
   class TaxCloud
+
+    def self.update_config
+      ::TaxCloud.configure do |config|
+        config.api_login_id = Spree::Config.taxcloud_api_login_id
+        config.api_key = Spree::Config.taxcloud_api_key
+        config.usps_username = Spree::Config.taxcloud_usps_user_id
+      end
+    end
+
     def self.transaction_from_order(order)
       stock_location = order.shipments.first.try(:stock_location) || Spree::StockLocation.active.where("city IS NOT NULL and state_id IS NOT NULL").first
       raise Spree.t(:ensure_one_valid_stock_location) unless stock_location

--- a/app/overrides/spree/admin/shared/_configuration_menu.rb
+++ b/app/overrides/spree/admin/shared/_configuration_menu.rb
@@ -1,5 +1,5 @@
 Deface::Override.new(
-  virtual_path:  "spree/admin/shared/_configuration_menu",
+  virtual_path:  "spree/admin/shared/sub_menu/_configuration",
   name: "add_tax_cloud_admin_menu_link",
   insert_bottom: "[data-hook='admin_configurations_sidebar_menu']",
   text: "<%= configurations_sidebar_menu_item 'Taxcloud Settings', edit_admin_tax_cloud_settings_path %>"

--- a/app/views/spree/admin/products/_edit_tax_cloud_tic.html.erb
+++ b/app/views/spree/admin/products/_edit_tax_cloud_tic.html.erb
@@ -1,6 +1,6 @@
 <div data-hook="admin_product_form_tax_cloud_tic">
   <%= f.field_container :tax_cloud_tic do %>
     <%= f.label :tax_cloud_tic_id, Spree.t(:tax_cloud_tic) %>
-    <%= f.text_field :tax_cloud_tic, size: 4, placeholder: Spree::Config.taxcloud_default_product_tic %>
+    <%= f.text_field :tax_cloud_tic, size: 5, placeholder: Spree::Config.taxcloud_default_product_tic %>
   <% end %>
 </div>

--- a/app/views/spree/admin/tax_cloud_settings/edit.html.erb
+++ b/app/views/spree/admin/tax_cloud_settings/edit.html.erb
@@ -1,4 +1,4 @@
-<%= render 'spree/admin/shared/configuration_menu' %>
+<%= render 'spree/admin/shared/sub_menu/configuration' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:tax_cloud_settings) %>
@@ -7,39 +7,41 @@
 <%= form_tag admin_tax_cloud_settings_path, method: :put do %>
   <div id="preferences" data-hook>
     <div class="row">
-      <div class="alpha six columns">
-        <fieldset class="security no-border-bottom">
-          <legend align="center"><%= Spree.t(:tax_cloud_api_login_and_key)%></legend>
-            <% @preferences_login.each do |key|
-                type = Spree::Config.preference_type(key) %>
-                <div class="field">
-                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, Spree::Config[key], type: type) %>
-                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
-                </div>
-            <% end %>
-          </fieldset>
-        </div>
-        <div class="omega six columns">
-          <fieldset class="currency no-border-bottom">
-            <legend align="center"><%= Spree.t(:tax_cloud_taxability_codes)%></legend>
-            <% @preferences_tic.each do |key|
-                type = Spree::Config.preference_type(key) %>
-                <div class="field">
-                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, Spree::Config[key], type: type) %>
-                  <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
-                </div>
-            <% end %>
-          </fieldset>
-        </div>
+
+      <div class="col-md-6">
+        <fieldset class="no-border-bottom">
+          <legend><%= Spree.t(:tax_cloud_api_login_and_key)%></legend>
+          <% @preferences_login.each do |key|
+              type = Spree::Config.preference_type(key) %>
+              <div class="form-group">
+                <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
+                <%= preference_field_tag(key, Spree::Config[key], type: type) %>
+                <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+              </div>
+          <% end %>
+        </fieldset>
       </div>
 
-      <div class="form-buttons filter-actions actions" data-hook="buttons">
-        <%= button Spree.t('actions.update'), 'refresh' %>
-        <span class="or"><%= Spree.t(:or) %></span>
-        <%= link_to_with_icon 'remove', Spree.t('actions.cancel'), edit_admin_tax_cloud_settings_url, class: 'button' %>
+      <div class="col-md-6">
+        <fieldset class="no-border-bottom">
+          <legend><%= Spree.t(:tax_cloud_taxability_codes)%></legend>
+          <% @preferences_tic.each do |key|
+              type = Spree::Config.preference_type(key) %>
+              <div class="form-group">
+                <%= label_tag(key, Spree.t(key)) + tag(:br) if type != :boolean %>
+                <%= preference_field_tag(key, Spree::Config[key], type: type) %>
+                <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
+              </div>
+          <% end %>
+        </fieldset>
       </div>
-    </fieldset>
+    </div>
+
+    <div class="form-buttons" data-hook="buttons">
+      <%= button Spree.t('actions.update'), 'refresh' %>
+      <span class="or"><%= Spree.t(:or) %></span>
+      <%= button_link_to Spree.t('actions.cancel'), edit_admin_tax_cloud_settings_url, icon: 'delete' %>
+    </div>
+
   </div>
 <% end %>


### PR DESCRIPTION
Hey,

I'm running Spree 3-0-stable, and wanted to use this gem.  I had to make a few changes to some of the admin views so that the configuration editor appeared in the admin menu.

I also tried to align the css classes with what is used in other admin config forms in Spree 3-0-stable, although I don't have a lot of experience developing admin extensions for Spree.

I also fixed a defect where changes to the TaxCloud preferences in the Spree admin would not take affect until the application was restarted.