### PR TITLE
Fixing NameError for Spree::CheckoutController when not using spree frontend

### DIFF
--- a/app/controllers/spree/frontend/checkout_controller_decorator.rb
+++ b/app/controllers/spree/frontend/checkout_controller_decorator.rb
@@ -1,11 +1,14 @@
-Spree::CheckoutController.class_eval do
-  rescue_from SpreeTaxCloud::Error do |exception|
-    flash[:error] = exception.message
-    redirect_to checkout_state_path(:address)
-  end
+# Currently the eager load paths with require every rb file in app/controllers
+if SpreeTaxCloud::Engine.frontend_available?
+  Spree::CheckoutController.class_eval do
+    rescue_from SpreeTaxCloud::Error do |exception|
+      flash[:error] = exception.message
+      redirect_to checkout_state_path(:address)
+    end
 
-  rescue_from TaxCloud::Errors::ApiError do |exception|
-    flash[:error] = Spree.t(:address_verification_failed)
-    redirect_to checkout_state_path(:address)
+    rescue_from TaxCloud::Errors::ApiError do |exception|
+      flash[:error] = Spree.t(:address_verification_failed)
+      redirect_to checkout_state_path(:address)
+    end
   end
 end


### PR DESCRIPTION
Guys,

I'm using this gem for spree 3-0-stable and api+core only. By default rails is requiring every rb file in the app/controllers directory. 

Even though the rails engine is only supposed to require the gem if frontend is available, eager_load_paths will require this decorator anyway. 

It's probably smarter to move these decorators out of the app/controllers directory since you want to control when if it gets loaded. 

My simple but ugly fix is add a big guard clause.

