### PR TITLE
Set spree dependencies to >= 3.1.0 and < 4.0

### DIFF
--- a/spree_tax_cloud.gemspec
+++ b/spree_tax_cloud.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.1.0'
 
-  spree_version = '~> 3.2.0.alpha'
+  spree_version = '>= 3.1.0', '< 4.0'
   s.add_dependency 'spree_backend', spree_version
   s.add_dependency 'spree_core', spree_version
 


### PR DESCRIPTION
This PR changes the version of spree related gems in gemspec to point at `>= 3.1.0` and `< 4.0`.